### PR TITLE
[BUGFIX] Use DMF FileStorage class to handle reading and writing of files (where possible)

### DIFF
--- a/src/DataProvider/PdfDataProvider.php
+++ b/src/DataProvider/PdfDataProvider.php
@@ -49,7 +49,7 @@ class PdfDataProvider extends DataProvider implements DataProcessorAwareInterfac
 
     public const DEFAULT_USE_CHECKBOX_PARSER = false;
 
-    protected const KEY_UNIQUE_DIRECTORY_IDENTIFIER =  'uniqueDirectoryIdentifier';
+    protected const KEY_UNIQUE_DIRECTORY_IDENTIFIER = 'uniqueDirectoryIdentifier';
 
     public function __construct(
         string $keyword,
@@ -74,6 +74,7 @@ class PdfDataProvider extends DataProvider implements DataProcessorAwareInterfac
         if (!$pdfDirectoryName) {
             throw new DigitalMarketingFrameworkException(self::KEY_UNIQUE_DIRECTORY_IDENTIFIER . ' is missing in the context.', 1699453570);
         }
+
         $dataProcessorContext = new DataProcessorContext($this->submission->getData(), $this->submission->getConfiguration());
         $pdfFormFields = [];
         $pdfFormFieldsMap = $this->getMapConfig(static::KEY_PDF_FORM_FIELDS);
@@ -83,6 +84,7 @@ class PdfDataProvider extends DataProvider implements DataProcessorAwareInterfac
                 $pdfFormFields[$pdfFieldName] = $pdfFieldValue;
             }
         }
+
         $settings = [
             'pdfTemplatePath' => $this->getConfig(static::KEY_PDF_TEMPLATE_PATH),
             'pdfOutputDir' => $pdfDirectoryName,
@@ -94,7 +96,8 @@ class PdfDataProvider extends DataProvider implements DataProcessorAwareInterfac
         if (!$pdfFileIdentifier) {
             throw new DigitalMarketingFrameworkException('Failed to create PDF, no reason given.', 1699453575);
         }
-        $pdfField = new FileValue;
+
+        $pdfField = new FileValue();
         $pdfField->setFileName($this->getConfig(static::KEY_PDF_OUTPUT_NAME));
         $pdfField->setRelativePath($pdfFileIdentifier);
         $pdfField->setMimeType('application/pdf');

--- a/src/DataProvider/PdfDataProvider.php
+++ b/src/DataProvider/PdfDataProvider.php
@@ -13,15 +13,19 @@ use DigitalMarketingFramework\Core\Context\ContextInterface;
 use DigitalMarketingFramework\Core\DataProcessor\DataProcessorAwareInterface;
 use DigitalMarketingFramework\Core\DataProcessor\DataProcessorAwareTrait;
 use DigitalMarketingFramework\Core\DataProcessor\DataProcessorContext;
+use DigitalMarketingFramework\Core\Exception\DigitalMarketingFrameworkException;
+use DigitalMarketingFramework\Core\FileStorage\FileStorageAwareInterface;
+use DigitalMarketingFramework\Core\FileStorage\FileStorageAwareTrait;
 use DigitalMarketingFramework\Core\Model\Data\Value\FileValue;
 use DigitalMarketingFramework\Distributor\Core\DataProvider\DataProvider;
 use DigitalMarketingFramework\Distributor\Core\Model\DataSet\SubmissionDataSetInterface;
 use DigitalMarketingFramework\Distributor\Core\Registry\RegistryInterface;
 use DigitalMarketingFramework\Distributor\Pdf\Service\PdfService;
 
-class PdfDataProvider extends DataProvider implements DataProcessorAwareInterface
+class PdfDataProvider extends DataProvider implements DataProcessorAwareInterface, FileStorageAwareInterface
 {
     use DataProcessorAwareTrait;
+    use FileStorageAwareTrait;
 
     public const KEY_FIELD = 'field';
 
@@ -45,6 +49,8 @@ class PdfDataProvider extends DataProvider implements DataProcessorAwareInterfac
 
     public const DEFAULT_USE_CHECKBOX_PARSER = false;
 
+    protected const KEY_UNIQUE_DIRECTORY_IDENTIFIER =  'uniqueDirectoryIdentifier';
+
     public function __construct(
         string $keyword,
         RegistryInterface $registry,
@@ -56,10 +62,18 @@ class PdfDataProvider extends DataProvider implements DataProcessorAwareInterfac
 
     protected function processContext(ContextInterface $context): void
     {
+        $uniqueDirectoryName = $this->pdfService->createUniqueDirectory($this->getConfig(static::KEY_PDF_OUTPUT_DIR));
+        if ($uniqueDirectoryName) {
+            $this->submission->getContext()[self::KEY_UNIQUE_DIRECTORY_IDENTIFIER] = $uniqueDirectoryName;
+        }
     }
 
     protected function process(): void
     {
+        $pdfDirectoryName = $this->submission->getContext()[self::KEY_UNIQUE_DIRECTORY_IDENTIFIER];
+        if (!$pdfDirectoryName) {
+            throw new DigitalMarketingFrameworkException(self::KEY_UNIQUE_DIRECTORY_IDENTIFIER . ' is missing in the context.', 1699453570);
+        }
         $dataProcessorContext = new DataProcessorContext($this->submission->getData(), $this->submission->getConfiguration());
         $pdfFormFields = [];
         $pdfFormFieldsMap = $this->getMapConfig(static::KEY_PDF_FORM_FIELDS);
@@ -69,18 +83,23 @@ class PdfDataProvider extends DataProvider implements DataProcessorAwareInterfac
                 $pdfFormFields[$pdfFieldName] = $pdfFieldValue;
             }
         }
-
         $settings = [
             'pdfTemplatePath' => $this->getConfig(static::KEY_PDF_TEMPLATE_PATH),
-            'pdfOutputDir' => $this->getConfig(static::KEY_PDF_OUTPUT_DIR),
+            'pdfOutputDir' => $pdfDirectoryName,
             'pdfOutputName' => $this->getConfig(static::KEY_PDF_OUTPUT_NAME),
             'pdfFormFields' => $pdfFormFields,
             'useCheckboxParser' => $this->getConfig(static::KEY_USE_CHECKBOX_PARSER),
         ];
-
-        $pdf = $this->pdfService->generatePdf($settings);
-        if (is_array($pdf)) {
-            $pdfField = FileValue::unpack($pdf);
+        $pdfFileIdentifier = $this->pdfService->generatePdf($settings);
+        if (!$pdfFileIdentifier) {
+            throw new DigitalMarketingFrameworkException('Failed to create PDF, no reason given.', 1699453575);
+        }
+        $pdfField = new FileValue;
+        $pdfField->setFileName($this->getConfig(static::KEY_PDF_OUTPUT_NAME));
+        $pdfField->setRelativePath($pdfFileIdentifier);
+        $pdfField->setMimeType('application/pdf');
+        $pdfField->setPublicUrl($this->fileStorage->getPublicUrl($pdfFileIdentifier));
+        if ($pdfField) {
             $this->setField($this->getConfig(static::KEY_FIELD), $pdfField);
         }
     }

--- a/src/DataProvider/PdfDataProvider.php
+++ b/src/DataProvider/PdfDataProvider.php
@@ -102,9 +102,7 @@ class PdfDataProvider extends DataProvider implements DataProcessorAwareInterfac
         $pdfField->setRelativePath($pdfFileIdentifier);
         $pdfField->setMimeType('application/pdf');
         $pdfField->setPublicUrl($this->fileStorage->getPublicUrl($pdfFileIdentifier));
-        if ($pdfField) {
-            $this->setField($this->getConfig(static::KEY_FIELD), $pdfField);
-        }
+        $this->setField($this->getConfig(static::KEY_FIELD), $pdfField);
     }
 
     public static function getSchema(): SchemaInterface

--- a/src/FPDM.php
+++ b/src/FPDM.php
@@ -7,7 +7,8 @@ use DigitalMarketingFramework\Core\Exception\DigitalMarketingFrameworkException;
 class FPDM extends \FPDM
 {
     /** @phpstan-impure */
-    function Error($msg) {
+    public function Error($msg): never
+    {
         throw new DigitalMarketingFrameworkException($msg, 1699365138);
     }
 }

--- a/src/FPDM.php
+++ b/src/FPDM.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace DigitalMarketingFramework\Distributor\Pdf;
+
+use DigitalMarketingFramework\Core\Exception\DigitalMarketingFrameworkException;
+
+class FPDM extends \FPDM
+{
+    /** @phpstan-impure */
+    function Error($msg) {
+        throw new DigitalMarketingFrameworkException($msg, 1699365138);
+    }
+}

--- a/src/Service/PdfService.php
+++ b/src/Service/PdfService.php
@@ -15,11 +15,11 @@ class PdfService implements FileStorageAwareInterface
     /**
      * @param array<mixed> $settings
      *
-     * @return string|bool the file identifier
+     * @return string|false the file identifier
      */
-    public function generatePdf(array $settings): string|bool
+    public function generatePdf(array $settings): string|false
     {
-        if (!is_array($settings['pdfFormFields']) || $settings['pdfOutputDir'] == '' || $settings['pdfOutputName'] == '' || $settings['pdfTemplatePath'] == '' || $settings['pdfTemplatePath'] == '') {
+        if (!is_array($settings['pdfFormFields']) || $settings['pdfOutputDir'] == '' || $settings['pdfOutputName'] == '' || $settings['pdfTemplatePath'] == '') {
             return false;
         }
         $processedFields = $settings['pdfFormFields'];
@@ -42,6 +42,7 @@ class PdfService implements FileStorageAwareInterface
                 throw new DigitalMarketingFrameworkException($e->getMessage(), $e->getCode(), $e);
             }
         }
+
         return $generatedPdfIdentifier;
     }
 

--- a/src/Service/PdfService.php
+++ b/src/Service/PdfService.php
@@ -4,13 +4,11 @@ namespace DigitalMarketingFramework\Distributor\Pdf\Service;
 
 use DigitalMarketingFramework\Core\FileStorage\FileStorageAwareInterface;
 use DigitalMarketingFramework\Core\FileStorage\FileStorageAwareTrait;
-use DigitalMarketingFramework\Typo3\Core\Utility\VendorAssetUtility;
 use Exception;
 use FPDM;
 
 class PdfService implements FileStorageAwareInterface
 {
-
     use FileStorageAwareTrait;
 
     /**
@@ -43,9 +41,11 @@ class PdfService implements FileStorageAwareInterface
             if (!$uniqueOutputDir) {
                 return false;
             }
+
             $generatedPdf = $uniqueOutputDir . '/' . $settings['pdfOutputName'];
             $this->fileStorage->putFileContents($generatedPdf, $mergedContent);
             unlink($tempFile);
+
             return ['fileName' => $settings['pdfOutputName'], 'publicUrl' => $generatedPdf, 'relativePath' => $generatedPdf, 'mimeType' => mime_content_type($generatedPdf)];
         } catch (Exception) {
             // TODO: REALLY catch errors like "FPDF-Merge Error: field companyname not found"
@@ -75,6 +75,7 @@ class PdfService implements FileStorageAwareInterface
         if ($this->fileStorage->folderExists($dir)) {
             return $dir;
         }
+
         return false;
     }
 }

--- a/src/Service/PdfService.php
+++ b/src/Service/PdfService.php
@@ -2,41 +2,50 @@
 
 namespace DigitalMarketingFramework\Distributor\Pdf\Service;
 
+use DigitalMarketingFramework\Core\FileStorage\FileStorageAwareInterface;
+use DigitalMarketingFramework\Core\FileStorage\FileStorageAwareTrait;
+use DigitalMarketingFramework\Typo3\Core\Utility\VendorAssetUtility;
 use Exception;
 use FPDM;
 
-class PdfService
+class PdfService implements FileStorageAwareInterface
 {
+
+    use FileStorageAwareTrait;
+
     /**
      * @param array<mixed> $settings
      *
      * @return array<mixed>|bool
      */
-    public function generatePdf($settings)
+    public function generatePdf(array $settings): array|bool
     {
-        if (!is_array($settings['pdfFormFields']) || $settings['pdfOutputDir'] == '' || $settings['pdfOutputName'] == '' || $settings['pdfTemplatePath'] == '' || !file_exists($settings['pdfTemplatePath'])) {
+        if (!is_array($settings['pdfFormFields']) || $settings['pdfOutputDir'] == '' || $settings['pdfOutputName'] == '' || $settings['pdfTemplatePath'] == '' || $settings['pdfTemplatePath'] == '') {
             return false;
         }
 
         $processedFields = $settings['pdfFormFields'];
 
-        $tempDir = $this->createUniqueTempDirectory($settings['pdfOutputDir']);
-        if (!$tempDir) {
-            return false;
-        }
-
-        $generatedPdf = $tempDir . '/' . $settings['pdfOutputName'];
+        $templateContents = $this->fileStorage->getFileContents($settings['pdfTemplatePath']);
+        $tempFile = $this->fileStorage->writeTempFile('', $templateContents, '.pdf');
 
         try {
-            $pdf = new FPDM($settings['pdfTemplatePath']); // @phpstan-ignore-line because the FPDM constructor gets its arguments via func_get_args()
+            $pdf = new FPDM($tempFile); // @phpstan-ignore-line because the FPDM constructor gets its arguments via func_get_args()
             if ($settings['useCheckboxParser']) {
                 $pdf->useCheckboxParser = true;
             }
 
             $pdf->Load($processedFields, true);
             $pdf->Merge();
-            $pdf->Output('F', $generatedPdf);
-
+            $pdf->Output('F', $tempFile);
+            $mergedContent = file_get_contents($tempFile);
+            $uniqueOutputDir = $this->createUniqueDirectory($settings['pdfOutputDir']);
+            if (!$uniqueOutputDir) {
+                return false;
+            }
+            $generatedPdf = $uniqueOutputDir . '/' . $settings['pdfOutputName'];
+            $this->fileStorage->putFileContents($generatedPdf, $mergedContent);
+            unlink($tempFile);
             return ['fileName' => $settings['pdfOutputName'], 'publicUrl' => $generatedPdf, 'relativePath' => $generatedPdf, 'mimeType' => mime_content_type($generatedPdf)];
         } catch (Exception) {
             // TODO: REALLY catch errors like "FPDF-Merge Error: field companyname not found"
@@ -49,23 +58,23 @@ class PdfService
      *
      * @return string|bool
      */
-    private function createUniqueTempDirectory(string $dir, int $maxTries = 500)
+    private function createUniqueDirectory(string $dir, int $maxTries = 500)
     {
-        if (!file_exists($dir)) {
-            mkdir($dir);
+        if (!$this->fileStorage->folderExists($dir)) {
+            $this->fileStorage->createFolder($dir);
         }
 
         $dir .= uniqid('pdf_') . '_';
         $tries = 0;
-        while ($tries < $maxTries && file_exists($dir . $tries)) {
+        while ($tries < $maxTries && $this->fileStorage->folderExists($dir . $tries)) {
             ++$tries;
         }
 
         $dir .= $tries;
-        if (!file_exists($dir) && mkdir($dir)) {
+        $this->fileStorage->createFolder($dir);
+        if ($this->fileStorage->folderExists($dir)) {
             return $dir;
         }
-
         return false;
     }
 }

--- a/src/Service/PdfService.php
+++ b/src/Service/PdfService.php
@@ -34,7 +34,7 @@ class PdfService implements FileStorageAwareInterface
                 if ($settings['useCheckboxParser']) {
                     $pdf->useCheckboxParser = true;
                 }
-                
+
                 $pdf->Load($processedFields, true);
                 $pdf->Merge();
                 $pdf->Output('F', $tempFile);

--- a/src/Service/PdfService.php
+++ b/src/Service/PdfService.php
@@ -22,6 +22,7 @@ class PdfService implements FileStorageAwareInterface
         if (!is_array($settings['pdfFormFields']) || $settings['pdfOutputDir'] == '' || $settings['pdfOutputName'] == '' || $settings['pdfTemplatePath'] == '') {
             return false;
         }
+
         $processedFields = $settings['pdfFormFields'];
         $templateContents = $this->fileStorage->getFileContents($settings['pdfTemplatePath']);
         $tempFile = $this->fileStorage->writeTempFile('', $templateContents, '.pdf');
@@ -33,6 +34,7 @@ class PdfService implements FileStorageAwareInterface
                 if ($settings['useCheckboxParser']) {
                     $pdf->useCheckboxParser = true;
                 }
+                
                 $pdf->Load($processedFields, true);
                 $pdf->Merge();
                 $pdf->Output('F', $tempFile);

--- a/src/Service/PdfService.php
+++ b/src/Service/PdfService.php
@@ -5,8 +5,8 @@ namespace DigitalMarketingFramework\Distributor\Pdf\Service;
 use DigitalMarketingFramework\Core\Exception\DigitalMarketingFrameworkException;
 use DigitalMarketingFramework\Core\FileStorage\FileStorageAwareInterface;
 use DigitalMarketingFramework\Core\FileStorage\FileStorageAwareTrait;
+use DigitalMarketingFramework\Distributor\Pdf\FPDM;
 use Exception;
-use FPDM;
 
 class PdfService implements FileStorageAwareInterface
 {
@@ -37,6 +37,8 @@ class PdfService implements FileStorageAwareInterface
             $pdf->Load($processedFields, true);
             $pdf->Merge();
             $pdf->Output('F', $tempFile);
+
+
             $mergedContent = file_get_contents($tempFile);
             $uniqueOutputDir = $this->createUniqueDirectory($settings['pdfOutputDir']);
             if (!$uniqueOutputDir) {

--- a/src/Service/PdfService.php
+++ b/src/Service/PdfService.php
@@ -2,6 +2,7 @@
 
 namespace DigitalMarketingFramework\Distributor\Pdf\Service;
 
+use DigitalMarketingFramework\Core\Exception\DigitalMarketingFrameworkException;
 use DigitalMarketingFramework\Core\FileStorage\FileStorageAwareInterface;
 use DigitalMarketingFramework\Core\FileStorage\FileStorageAwareTrait;
 use Exception;
@@ -47,9 +48,8 @@ class PdfService implements FileStorageAwareInterface
             unlink($tempFile);
 
             return ['fileName' => $settings['pdfOutputName'], 'publicUrl' => $generatedPdf, 'relativePath' => $generatedPdf, 'mimeType' => mime_content_type($generatedPdf)];
-        } catch (Exception) {
-            // TODO: REALLY catch errors like "FPDF-Merge Error: field companyname not found"
-            return false;
+        } catch (Exception $e) {
+            throw new DigitalMarketingFrameworkException($e->getMessage(), $e->getCode(), $e);
         }
     }
 


### PR DESCRIPTION
Both pdfOutputDir and pdfTemplatePath must now be DMF FileStorage readable file identifiers